### PR TITLE
[ SC ] # IMPLEMENT A FUNCTION FOR THE TUTOR TO UPLOAD A CERTIFICATE AS NFT #5

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -12,3 +12,9 @@ pub const INSUFFICIENT_PAYMENT: felt252 = 'Insufficient payment';
 pub const FEE_TRANSFER_FAILED: felt252 = 'Fee transfer failed';
 /// Thrown when attempting to pay for a course
 pub const TUTOR_PAYMENT_FAILED: felt252 = 'Tutor payment failed';
+/// Thrown when attempting to issue certificate for a course not completed by student
+pub const COURSE_NOT_COMPLETED: felt252 = 'Course not completed by student';
+/// Thrown when someone other than the course tutor tries to issue a certificate
+pub const NOT_COURSE_TUTOR: felt252 = 'Not the course tutor';
+/// Thrown when trying to complete a course while not enrolled
+pub const STUDENT_NOT_ENROLLED: felt252 = 'Student not enrolled';

--- a/src/interfaces/ISkillNet.cairo
+++ b/src/interfaces/ISkillNet.cairo
@@ -41,6 +41,13 @@ pub trait ISkillNet<TContractState> {
     fn mint_completion_nft(
         ref self: TContractState, course_id: u256, student: ContractAddress,
     ) -> u256;
+    
+    fn upload_certificate_nft(
+        ref self: TContractState, 
+        course_id: u256, 
+        student: ContractAddress, 
+        certificate_title: felt252,
+    ) -> u256;
 
     // fn get_student_nfts(self: @TContractState, student: ContractAddress) -> Array<u256>;
 

--- a/src/interfaces/ISkillNet.cairo
+++ b/src/interfaces/ISkillNet.cairo
@@ -41,11 +41,11 @@ pub trait ISkillNet<TContractState> {
     fn mint_completion_nft(
         ref self: TContractState, course_id: u256, student: ContractAddress,
     ) -> u256;
-    
+
     fn upload_certificate_nft(
-        ref self: TContractState, 
-        course_id: u256, 
-        student: ContractAddress, 
+        ref self: TContractState,
+        course_id: u256,
+        student: ContractAddress,
         certificate_title: felt252,
     ) -> u256;
 

--- a/src/skillnet.cairo
+++ b/src/skillnet.cairo
@@ -6,8 +6,8 @@ pub mod SkillNet {
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use crate::errors::{
-        COURSE_IS_FREE, COURSE_NOT_FOUND, COURSE_NOT_COMPLETED, FEE_TRANSFER_FAILED, 
-        INSUFFICIENT_PAYMENT, NOT_COURSE_TUTOR, PAYMENT_FAILED, TUTOR_PAYMENT_FAILED, 
+        COURSE_IS_FREE, COURSE_NOT_FOUND, COURSE_NOT_COMPLETED, FEE_TRANSFER_FAILED,
+        INSUFFICIENT_PAYMENT, NOT_COURSE_TUTOR, PAYMENT_FAILED, TUTOR_PAYMENT_FAILED,
         USER_ALREADY_ENROLLED,
     };
     use crate::interfaces::ISkillNet::ISkillNet;
@@ -211,32 +211,32 @@ pub mod SkillNet {
             79
         }
 
-        /// @notice Allows a tutor to upload a certificate as an NFT for a student who completed their course
-        /// @dev Only the course tutor can issue certificates for their own courses
+        /// @notice Allows a tutor to upload a certificate as an NFT for a student who completed
+        /// their course @dev Only the course tutor can issue certificates for their own courses
         /// @param course_id The ID of the course the certificate is for
         /// @param student The address of the student receiving the certificate
         /// @param certificate_title The title to be displayed on the certificate
         /// @return token_id The unique ID of the minted NFT certificate
         fn upload_certificate_nft(
-            ref self: ContractState, 
-            course_id: u256, 
-            student: ContractAddress, 
+            ref self: ContractState,
+            course_id: u256,
+            student: ContractAddress,
             certificate_title: felt252,
         ) -> u256 {
             // Get the course from storage
             let course = self.courses.read(course_id);
-            
+
             // Ensure the course exists
             assert(course.id == course_id, COURSE_NOT_FOUND);
-            
+
             // Ensure the caller is the tutor of the course
             let caller = get_caller_address();
             assert(caller == course.tutor, NOT_COURSE_TUTOR);
-            
+
             // Check if the student has completed the course
             let is_completed = self.completions.entry(student).entry(course_id).read();
             assert(is_completed, COURSE_NOT_COMPLETED);
-            
+
             // Create certificate metadata
             let metadata = CourseMetadata {
                 course_id,
@@ -245,10 +245,10 @@ pub mod SkillNet {
                 student_address: student,
                 tutor_address: caller,
             };
-            
+
             // Mint the NFT certificate
             let token_id = self.mint(student, course_id, metadata);
-            
+
             token_id
         }
 

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -343,29 +343,29 @@ fn test_upload_certificate_nft() {
 
     // Create a course
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
-    
+
     // Create a paid course
     let course_id = contract.create_course(123456, 654321, 100, false, 789012);
-    
+
     // Setup student address
     let student: ContractAddress = contract_address_const::<'student'>();
-    
+
     // Fund the student and enroll them in the course
     contract.deposit_funds(student, 1000_u256);
     contract.enroll_course(course_id, student);
-    
+
     // Mark the course as completed by the student
     contract.complete_course(course_id, student);
-    
+
     // Create certificate title
     let certificate_title: felt252 = 'Completion Certificate';
-    
+
     // Upload certificate as NFT (admin is the tutor in this case)
     let token_id = contract.upload_certificate_nft(course_id, student, certificate_title);
-    
+
     // Verify token ID is returned
     assert(token_id == 100, 'Incorrect token ID');
-    
+
     // Verify ownership (in a real test, we'd check ownership via the NFT contract)
     let owner = contract.owner_of(token_id);
     assert(owner == admin_address, 'Incorrect token owner');
@@ -377,10 +377,10 @@ fn test_upload_certificate_nft_course_not_found() {
     // Setup contract and addresses
     let (contract_address, admin_address, _, _, _) = setup();
     let contract = ISkillNetDispatcher { contract_address };
-    
+
     // Create a student address
     let student: ContractAddress = contract_address_const::<'student'>();
-    
+
     // Try to upload certificate for non-existent course
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     contract.upload_certificate_nft(999, student, 'Certificate');
@@ -392,20 +392,20 @@ fn test_upload_certificate_nft_not_tutor() {
     // Setup contract and addresses
     let (contract_address, admin_address, _, _, _) = setup();
     let contract = ISkillNetDispatcher { contract_address };
-    
+
     // Create a course
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     let course_id = contract.create_course(123456, 654321, 100, false, 789012);
-    
+
     // Setup student and another user addresses
     let student: ContractAddress = contract_address_const::<'student'>();
     let other_user: ContractAddress = contract_address_const::<'other_user'>();
-    
+
     // Fund the student and enroll them in the course
     contract.deposit_funds(student, 1000_u256);
     contract.enroll_course(course_id, student);
     contract.complete_course(course_id, student);
-    
+
     // Try to upload certificate as someone who isn't the tutor
     cheat_caller_address(contract_address, other_user, CheatSpan::Indefinite);
     contract.upload_certificate_nft(course_id, student, 'Certificate');
@@ -417,18 +417,18 @@ fn test_upload_certificate_nft_course_not_completed() {
     // Setup contract and addresses
     let (contract_address, admin_address, _, _, _) = setup();
     let contract = ISkillNetDispatcher { contract_address };
-    
+
     // Create a course
     cheat_caller_address(contract_address, admin_address, CheatSpan::Indefinite);
     let course_id = contract.create_course(123456, 654321, 100, false, 789012);
-    
+
     // Setup student address
     let student: ContractAddress = contract_address_const::<'student'>();
-    
+
     // Fund the student and enroll them in the course
     contract.deposit_funds(student, 1000_u256);
     contract.enroll_course(course_id, student);
-    
+
     // Try to upload certificate without completing the course
     contract.upload_certificate_nft(course_id, student, 'Certificate');
 }


### PR DESCRIPTION
* Introduced new error constants for course completion and tutor validation.
* Implemented `upload_certificate_nft` function to allow tutors to issue certificates as NFTs for students who have completed their courses.
* Added checks to ensure the course exists, the caller is the course tutor, and the student has completed the course before issuing a certificate.
* Expanded test coverage to validate the new functionality and error handling scenarios.